### PR TITLE
Copy Serial implementation from mckuhei

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(nuked-sc55)
 target_sources(nuked-sc55
     PRIVATE
     src/midi.h
+    src/serial.h
     src/main_frontend.cpp # main() is here!
 )
 
@@ -97,6 +98,12 @@ if(USE_RTMIDI)
     target_sources(nuked-sc55 PRIVATE src/midi_rtmidi.cpp)
 elseif(WIN32)
     target_sources(nuked-sc55 PRIVATE src/midi_win32.cpp)
+endif()
+
+if(UNIX)
+    target_sources(nuked-sc55 PRIVATE src/serial_posix.cpp)
+elseif(WIN32)
+    target_sources(nuked-sc55 PRIVATE src/serial_win32.cpp)
 endif()
 
 target_link_libraries(nuked-sc55 PRIVATE SDL2::SDL2 SDL2::SDL2main nuked-sc55-backend)
@@ -123,6 +130,7 @@ endif()
 add_executable(nuked-sc55-render)
 target_sources(nuked-sc55-render
     PRIVATE
+    src/serial.h src/serial_dummy.cpp
     src/render_frontend.cpp
     src/smf.cpp src/smf.h
     src/wav.cpp src/wav.h

--- a/src/emu.h
+++ b/src/emu.h
@@ -46,6 +46,7 @@
 struct EMU_Options
 {
     bool enable_lcd;
+    std::string serial_type;
 };
 
 enum class EMU_SystemReset {

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -740,7 +740,7 @@ void LCD_HandleEvent(lcd_t& lcd, const SDL_Event& sdl_event)
                 if (relval < -50) {
                     relval = -50;
                 }
-                lcd.volume += relval / (lcd.volume > 0.775f ? 10000.0f : 400.0f); // Prevent someone make sound too loud (like me)
+                lcd.volume += relval / (lcd.volume > 0.8f ? 10000.0f : 400.0f); // Prevent someone make sound too loud (like me)
                 if (lcd.volume > 1.0f) {
                     lcd.volume = 1.0f;
                 }

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -73,7 +73,7 @@ struct lcd_t {
     uint32_t drag_volume_knob = 0;
     uint32_t background_enabled = 0;
 
-    float volume = 0.775f;
+    float volume = 0.8f;
 
     SDL_Window *window = nullptr;
     SDL_Renderer *renderer = nullptr;

--- a/src/main_frontend.cpp
+++ b/src/main_frontend.cpp
@@ -39,6 +39,7 @@
 #include "audio.h"
 #include "cast.h"
 #include "pcm.h"
+#include "serial.h"
 #include <SDL.h>
 #include <cinttypes>
 #include <optional>
@@ -108,6 +109,8 @@ struct FE_Parameters
     bool help = false;
     std::string midiin_device;
     std::string midiout_device;
+    std::string serial_type;
+    std::string serial_port;
     std::string audio_device;
     uint32_t page_size = 512;
     uint32_t page_num = 32;
@@ -563,7 +566,7 @@ bool FE_CreateInstance(FE_Application& container, const std::filesystem::path& b
 
     fe->format = params.output_format;
 
-    if (!fe->emu.Init(EMU_Options { .enable_lcd = !params.no_lcd }))
+    if (!fe->emu.Init(EMU_Options { .enable_lcd = !params.no_lcd, .serial_type = params.serial_type }))
     {
         fprintf(stderr, "ERROR: Failed to init emulator.\n");
         return false;
@@ -633,6 +636,7 @@ enum class FE_ParseError
     UnknownArgument,
     RomDirectoryNotFound,
     FormatInvalid,
+    SerialTypeInvalid,
 };
 
 const char* FE_ParseErrorStr(FE_ParseError err)
@@ -657,6 +661,8 @@ const char* FE_ParseErrorStr(FE_ParseError err)
             return "Rom directory doesn't exist";
         case FE_ParseError::FormatInvalid:
             return "Output format invalid";
+        case FE_ParseError::SerialTypeInvalid:
+            return "Serial Type Invalid";
     }
     return "Unknown error";
 }
@@ -689,6 +695,31 @@ FE_ParseError FE_ParseCommandLine(int argc, char* argv[], FE_Parameters& result)
             }
 
             result.midiout_device = reader.Arg();
+        }
+        else if (reader.Any("-st", "--serial_type"))
+        {
+            if(!reader.Next())
+            {
+                return FE_ParseError::UnexpectedEnd;
+            }
+
+            if(reader.Arg() == "rs422" || reader.Arg() == "rs232c_1" || reader.Arg() == "rs232c_2")
+            {
+                result.serial_type = reader.Arg();
+            }
+            else
+            {
+                return FE_ParseError::SerialTypeInvalid;
+            }
+        }
+        else if(reader.Any("-sp", "--serialport"))
+        {
+            if(!reader.Next())
+            {
+                return FE_ParseError::UnexpectedEnd;
+            }
+
+            result.serial_port = reader.Arg();
         }
         else if (reader.Any("-a", "--audio-device"))
         {
@@ -872,12 +903,18 @@ General options:
   -?, -h, --help                                Display this information.
 
 Audio options:
-  -pi, --portin      <device_name_or_number>    Set MIDI input port.
-  -po, --portout     <device_name_or_number>    Set MIDI output port.
   -a, --audio-device <device_name_or_number>    Set output audio device.
   -b, --buffer-size  <page_size>[:page_count]   Set Audio Buffer size.
   -f, --format       s16|s32|f32                Set output format.
   --disable-oversampling                        Halves output frequency.
+
+MIDI port options (default, unless set to serial):
+  -pi, --portin      <device_name_or_number>    Set MIDI input port.
+  -po, --portout     <device_name_or_number>    Set MIDI output port.
+
+Serial Port options:
+  -st, --serial_type rs422|rs232c_1|rs232c_2    Set serial connection type
+  -sp, --serialport  <serial_io_port>           Set the serial port/named pipe/unix socket for serial I/O.
 
 Emulator options:
   -r, --reset     gs|gm                         Reset system in GS or GM mode.
@@ -982,13 +1019,28 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (!MIDI_Init(frontend, params.midiin_device, params.midiout_device))
+    if(!params.serial_type.empty() && !params.serial_port.empty())
     {
-        fprintf(stderr, "ERROR: Failed to initialize the MIDI Ports.\nWARNING: Continuing without MIDI Ports...\n");
-        fflush(stderr);
+        if(params.romset!=Romset::MK2 || params.romset!=Romset::ST)
+        {
+            fprintf(stderr, "FATAL ERROR: Serial port support is only available in SC-55mkII and SC-55ST models only.\n");
+            fflush(stderr);
+            return 1;
+        }
+        if(!SERIAL_Init(frontend, params.serial_port))
+        {
+            fprintf(stderr, "ERROR: Failed to initialize the Serial Port.\nWARNING: Continuing without Serial Port...\n");
+            fflush(stderr);
+        }
     }
-
-    
+    else
+    {
+        if (!MIDI_Init(frontend, params.midiin_device, params.midiout_device))
+        {
+            fprintf(stderr, "ERROR: Failed to initialize the MIDI Ports.\nWARNING: Continuing without MIDI Ports...\n");
+            fflush(stderr);
+        }
+    }
 
     for (size_t i = 0; i < frontend.instances_in_use; ++i)
     {

--- a/src/mcu.cpp
+++ b/src/mcu.cpp
@@ -132,15 +132,15 @@ READ_RCU:
             case 2: // SW
                 switch (mcu.sw_pos)
                 {
-                case 0:
+                case Computerswitch::RS422:
+                    return ANALOG_LEVEL_SW_0; // Mac (RS422)
+                case Computerswitch::RS232C_1:
+                    return ANALOG_LEVEL_SW_1; // PC-1 (RS232C-1)
+                case Computerswitch::RS232C_2:
+                    return ANALOG_LEVEL_SW_2; // PC-2 (RS232C-2)
                 default:
-                    return ANALOG_LEVEL_SW_0;
-                case 1:
-                    return ANALOG_LEVEL_SW_1;
-                case 2:
-                    return ANALOG_LEVEL_SW_2;
-                case 3:
-                    return ANALOG_LEVEL_SW_3;
+                case Computerswitch::MIDI:
+                    return ANALOG_LEVEL_SW_3; // MIDI
                 }
             case 3: // RCU
                 goto READ_RCU;
@@ -757,6 +757,18 @@ void MCU_Write16(mcu_t& mcu, uint32_t address, uint16_t value)
     address &= ~1;
     MCU_Write(mcu, address, value >> 8);
     MCU_Write(mcu, address + 1, value & 0xff);
+}
+
+void MCU_SetSerial(mcu_t& mcu, std::string serialtype)
+{
+    if(serialtype == "rs422")
+        mcu.sw_pos = Computerswitch::RS422;
+    else if(serialtype == "rs232c_1")
+        mcu.sw_pos = Computerswitch::RS232C_1;
+    else if(serialtype == "rs232c_2")
+        mcu.sw_pos = Computerswitch::RS232C_2;
+    else
+        mcu.sw_pos = Computerswitch::MIDI;
 }
 
 void MCU_ReadInstruction(mcu_t& mcu)

--- a/src/mcu.h
+++ b/src/mcu.h
@@ -300,7 +300,7 @@ struct mcu_t {
     uint16_t operand_data = 0;
     uint8_t opcode_extended = 0;
 
-    uint16_t volume = 8250;
+    uint16_t volume = 10386;
 
     void* callback_userdata = nullptr;
     mcu_sample_callback sample_callback = MCU_DefaultSampleCallback;

--- a/src/mcu.h
+++ b/src/mcu.h
@@ -203,6 +203,13 @@ enum class Romset {
     SC155MK2,
 };
 
+enum class Computerswitch {
+    RS422,
+    RS232C_1,
+    RS232C_2,
+    MIDI
+};
+
 constexpr size_t ROMSET_COUNT = 9;
 
 typedef void(*mcu_sample_callback)(void* userdata, const AudioFrame<int32_t>& frame);
@@ -234,7 +241,6 @@ struct mcu_t {
 
     uint16_t ad_val[4]{};
     uint8_t ad_nibble = 0;
-    uint8_t sw_pos = 3;
     uint8_t io_sd = 0;
 
     submcu_t* sm = nullptr;
@@ -252,7 +258,13 @@ struct mcu_t {
     uint64_t uart_rx_delay = 0;
     uint64_t uart_tx_delay = 0;
 
+    uint8_t uart_serial_rx_byte = 0;
+    uint64_t uart_serial_rx_delay = 0;
+    uint64_t uart_serial_tx_delay = 0;
+
+
     Romset romset = Romset::MK2;
+    Computerswitch sw_pos = Computerswitch::MIDI;
 
     int is_mk1 = 0; // 0 - SC-55mkII, SC-55ST. 1 - SC-55, CM-300/SCC-1
     int is_cm300 = 0; // 0 - SC-55, 1 - CM-300/SCC-1
@@ -309,6 +321,8 @@ uint16_t MCU_Read16(mcu_t& mcu, uint32_t address);
 uint32_t MCU_Read32(mcu_t& mcu, uint32_t address);
 void MCU_Write(mcu_t& mcu, uint32_t address, uint8_t value);
 void MCU_Write16(mcu_t& mcu, uint32_t address, uint16_t value);
+
+void MCU_SetSerial(mcu_t& mcu, std::string serialtype);
 
 inline uint32_t MCU_GetAddress(uint8_t page, uint16_t address) {
     return ((uint32_t)page << 16) + address;

--- a/src/serial.h
+++ b/src/serial.h
@@ -32,54 +32,15 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 #pragma once
-#include <stdint.h>
 
-struct mcu_t;
+#include <cstdint>
+#include <string>
 
-enum {
-    SM_STATUS_C = 1,
-    SM_STATUS_Z = 2,
-    SM_STATUS_I = 4,
-    SM_STATUS_D = 8,
-    SM_STATUS_B = 16,
-    SM_STATUS_T = 32,
-    SM_STATUS_V = 64,
-    SM_STATUS_N = 128
-};
+struct FE_Application;
+struct submcu_t;
 
-struct submcu_t {
-    uint16_t pc = 0;
-    uint8_t a = 0;
-    uint8_t x = 0;
-    uint8_t y = 0;
-    uint8_t s = 0;
-    uint8_t sr = 0;
-    uint64_t cycles = 0;
-    uint8_t sleep = 0;
-    mcu_t* mcu = nullptr;
-    uint8_t rom[4096]{};
-
-    uint8_t ram[128]{};
-    uint8_t shared_ram[192]{};
-    uint8_t access[0x18]{};
-
-    uint8_t p0_dir = 0;
-    uint8_t p1_dir = 0;
-
-    uint8_t device_mode[32]{};
-    uint8_t cts = 0;
-
-    uint64_t timer_cycles = 0;
-    uint8_t timer_prescaler = 0;
-    uint8_t timer_counter = 0;
-
-    uint8_t uart_rx_gotbyte = 0;
-    uint8_t uart_serial_rx_gotbyte = 0;
-};
-
-void SM_Init(submcu_t& sm, mcu_t& mcu);
-void SM_Reset(submcu_t& sm);
-void SM_Update(submcu_t& sm, uint64_t cycles);
-void SM_SysWrite(submcu_t& sm, uint32_t address, uint8_t data);
-uint8_t SM_SysRead(submcu_t& sm, uint32_t address);
-void SM_PostUART(submcu_t& sm, uint8_t data);
+bool SERIAL_Init(FE_Application& fe, std::string_view serial_port);
+void SERIAL_Update(submcu_t& sm);
+bool SERIAL_HasData();
+uint8_t SERIAL_ReadUART();
+void SERIAL_PostUART(uint8_t data);

--- a/src/serial_dummy.cpp
+++ b/src/serial_dummy.cpp
@@ -31,55 +31,17 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  */
-#pragma once
-#include <stdint.h>
 
-struct mcu_t;
+#include "serial.h"
 
-enum {
-    SM_STATUS_C = 1,
-    SM_STATUS_Z = 2,
-    SM_STATUS_I = 4,
-    SM_STATUS_D = 8,
-    SM_STATUS_B = 16,
-    SM_STATUS_T = 32,
-    SM_STATUS_V = 64,
-    SM_STATUS_N = 128
-};
+bool SERIAL_Init(FE_Application& fe, std::string_view serial_port)
+{
+    (void)fe;
+    (void)serial_port;
 
-struct submcu_t {
-    uint16_t pc = 0;
-    uint8_t a = 0;
-    uint8_t x = 0;
-    uint8_t y = 0;
-    uint8_t s = 0;
-    uint8_t sr = 0;
-    uint64_t cycles = 0;
-    uint8_t sleep = 0;
-    mcu_t* mcu = nullptr;
-    uint8_t rom[4096]{};
-
-    uint8_t ram[128]{};
-    uint8_t shared_ram[192]{};
-    uint8_t access[0x18]{};
-
-    uint8_t p0_dir = 0;
-    uint8_t p1_dir = 0;
-
-    uint8_t device_mode[32]{};
-    uint8_t cts = 0;
-
-    uint64_t timer_cycles = 0;
-    uint8_t timer_prescaler = 0;
-    uint8_t timer_counter = 0;
-
-    uint8_t uart_rx_gotbyte = 0;
-    uint8_t uart_serial_rx_gotbyte = 0;
-};
-
-void SM_Init(submcu_t& sm, mcu_t& mcu);
-void SM_Reset(submcu_t& sm);
-void SM_Update(submcu_t& sm, uint64_t cycles);
-void SM_SysWrite(submcu_t& sm, uint32_t address, uint8_t data);
-uint8_t SM_SysRead(submcu_t& sm, uint32_t address);
-void SM_PostUART(submcu_t& sm, uint8_t data);
+    return true;
+}
+void SERIAL_Update() {}
+bool SERIAL_HasData() { return false; }
+uint8_t SERIAL_ReadUART() { return 0x0; }
+void SERIAL_PostUART(uint8_t data) {}

--- a/src/serial_posix.cpp
+++ b/src/serial_posix.cpp
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2021, 2024 nukeykt
+ *
+ *  Redistribution and use of this code or any derivative works are permitted
+ *  provided that the following conditions are met:
+ *
+ *   - Redistributions may not be sold, nor may they be used in a commercial
+ *     product or activity.
+ *
+ *   - Redistributions that are modified from the original source must include the
+ *     complete source code, including the source code for all components used by a
+ *     binary built from the modified sources. However, as a special exception, the
+ *     source code distributed need not include anything that is normally distributed
+ *     (in either source or binary form) with the major components (compiler, kernel,
+ *     and so on) of the operating system on which the executable runs, unless that
+ *     component itself accompanies the executable.
+ *
+ *   - Redistributions must reproduce the above copyright notice, this list of
+ *     conditions and the following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "serial.h"
+#include "SDL.h"
+#include <cstdio>
+#include <fcntl.h> // Contains file controls like O_RDWR
+#include <errno.h> // Error integer codes
+#include <cstring> // strerror() function
+#include <termios.h> // Contains POSIX terminal control definitions
+#include <unistd.h> // open(), write(), read(), close()
+#include <vector>
+
+#define BUFFER_SIZE 4096
+#define INVALID_VALUE -1
+
+SDL_mutex *linux_io_lock = nullptr;
+SDL_Thread *linux_io_thread = nullptr;
+bool linux_thread_run = false; 
+
+class SerialHandler
+{
+    private:
+        bool serial_init = false;
+        int port_handle = INVALID_VALUE;
+        
+        uint8_t linux_read_buffer[BUFFER_SIZE];
+        uint8_t * linux_read_ptr = linux_read_buffer;
+        uint8_t * linux_read_end = linux_read_buffer;
+        bool read_pending = true;
+        
+        const uint8_t * linux_read_limit = linux_read_buffer + BUFFER_SIZE;
+        uint8_t linux_write_buffer[BUFFER_SIZE];
+        uint8_t * linux_write_ptr = linux_write_buffer;
+        uint8_t * linux_write_end = linux_write_buffer;
+        const uint8_t * linux_write_limit = linux_write_buffer + BUFFER_SIZE;
+        bool write_pending = false;
+    public:
+        bool SerialInit(std::string_view serial_port);
+        void SerialClose();
+        bool IsSerialInit() { return serial_init && port_handle!=INVALID_VALUE; }
+        void ResetReadPending() { read_pending = false; }
+        void SetReadPending() { read_pending = true; }
+        bool IsReadPending() { return read_pending; }
+        void ResetWritePending() { write_pending = false; }
+        void SetWritePending() { write_pending = true; }
+        bool IsWritePending() { return write_pending; }
+        int SerialIOUpdate();
+        std::vector<uint8_t> GetReadBytes();
+        void SetWriteBytes(std::vector<uint8_t> write_data);
+};
+
+bool SerialHandler::SerialInit(std::string_view serial_port)
+{
+    char *path = new char[serial_port.length()];
+    strcpy(path, std::string(serial_port).c_str());
+
+    port_handle = open(path, O_RDWR|O_NOCTTY);
+    if(port_handle == INVALID_VALUE)
+    {
+        fprintf(stderr, "Failed to open serial port: %s\n", path);
+        return false;
+    }
+
+    termios tty_handle;
+    // Read in existing settings, and handle any error
+    if(tcgetattr(port_handle, &tty_handle) != 0) {
+        fprintf(stderr, "Error %i from getting tty attributes: %s\n", errno, strerror(errno));
+        return false;
+    }
+
+    // Clear parity bit, stop field (use only one stop bit) and data size bits.
+    tty_handle.c_cflag &= ~(PARENB|CSTOPB|CSIZE);
+    // 8 bits per byte, turn on READ and ignore ctrl lines
+    tty_handle.c_cflag |= (CS8|CREAD|CLOCAL);
+
+    // Disable echo, erasure, new-line echo ,interpretation of INTR, QUIT and SUSP & Turn off s/w flow ctrl
+    tty_handle.c_iflag &= ~(ICANON|ECHO|ECHOE|ECHONL|ISIG|IXON|IXOFF|IXANY);
+    tty_handle.c_iflag &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL); // Disable any special handling of received bytes
+
+    tty_handle.c_oflag &= ~(OPOST|ONLCR); // Prevent special interpretation of output bytes (e.g. newline chars)
+    // Prevent conversion of newline to carriage return/line feed
+
+    tty_handle.c_cc[VTIME] = 0;    // Do not wait, process asap
+    tty_handle.c_cc[VMIN] = 0;
+
+    tcflush(port_handle, TCIFLUSH);  
+
+    // Save tty settings, also checking for error
+    if (tcsetattr(port_handle, TCSANOW, &tty_handle) != 0) {
+        fprintf(stderr, "Error %i from getting tty attributes: %s\n", errno, strerror(errno));
+        return false;
+    }
+
+    fprintf(stderr, "Opened serial port %s\n", path);
+    serial_init = true;
+    return true;
+}
+
+void SerialHandler::SerialClose()
+{
+    if(!IsSerialInit())
+        return;
+
+    close(port_handle);
+    port_handle = INVALID_VALUE;
+    serial_init = false;
+}
+
+int SerialHandler::SerialIOUpdate()
+{
+
+    if(!IsReadPending())
+    {
+        SDL_LockMutex(linux_io_lock);
+
+        linux_read_ptr = linux_read_buffer;
+        linux_read_end = linux_read_buffer;
+        
+        int16_t read_bytes = read(port_handle, linux_read_end, BUFFER_SIZE * sizeof(uint8_t));
+        if(read_bytes == INVALID_VALUE)
+        {
+            fprintf(stderr, "Error %i reading from serial port: %s\n", errno, strerror(errno));
+            SDL_UnlockMutex(linux_io_lock);
+            return INVALID_VALUE;
+        }
+        if(read_bytes > 0)
+        {
+            linux_read_end += read_bytes;
+            SetReadPending();
+        }
+        
+        SDL_UnlockMutex(linux_io_lock);
+    }
+
+    if(IsWritePending())
+    {
+        SDL_LockMutex(linux_io_lock);
+        
+        int16_t write_len = linux_write_end - linux_write_ptr;
+        int16_t write_bytes = write(port_handle, linux_write_ptr, write_len * sizeof(uint8_t));
+        if(write_len < 0)
+        {
+            fprintf(stderr, "Error %i writing to serial port: %s\n", errno, strerror(errno));
+            SDL_UnlockMutex(linux_io_lock);
+            return INVALID_VALUE;
+        }
+        if(write_bytes > 0)
+        {
+            linux_write_ptr += write_bytes;
+            if(linux_write_ptr >= linux_write_end)
+            {
+                linux_write_ptr = linux_write_buffer;
+                linux_write_end = linux_write_buffer;
+                ResetWritePending();
+            }
+        }
+
+        SDL_UnlockMutex(linux_io_lock);
+    }
+    return 0;
+}
+
+std::vector<uint8_t> SerialHandler::GetReadBytes()
+{
+    std::vector<uint8_t> read_bytes;
+    while(linux_read_ptr < linux_read_end)
+        read_bytes.push_back(*linux_read_ptr++);
+
+    return read_bytes;
+}
+
+void SerialHandler::SetWriteBytes(std::vector<uint8_t> write_data)
+{
+    for(auto byte:write_data)
+        *linux_write_end++ = byte;
+}
+
+static SerialHandler *shandler = nullptr;
+std::vector<uint8_t> read_buffer;
+std::vector<uint8_t> write_buffer;
+
+int SDLCALL Linux_IO_Run(void *ptr)
+{
+    while(linux_thread_run)
+    {
+        shandler->SerialIOUpdate();
+    }
+    return 0;
+}
+
+bool SERIAL_Init(FE_Application& fe, std::string_view serial_port)
+{
+    (void)fe;
+
+    shandler = new SerialHandler;
+    if(!shandler->SerialInit(serial_port))
+        return false;
+    
+    linux_io_lock = SDL_CreateMutex();
+    linux_io_thread = SDL_CreateThread(Linux_IO_Run, "LinuxIO", nullptr);
+
+    return true;
+}
+
+bool SERIAL_HasData() 
+{
+    if(shandler == nullptr || !shandler->IsSerialInit())
+        return false;
+
+    return !read_buffer.empty();
+}
+
+void SERIAL_Update(submcu_t& sm) 
+{
+    (void)sm;
+    
+    if(shandler == nullptr || !shandler->IsSerialInit())
+        return;
+
+    if(shandler->IsReadPending() && read_buffer.empty())
+    {
+        read_buffer = shandler->GetReadBytes();
+        shandler->ResetReadPending();
+    }
+    if(!shandler->IsWritePending() && !write_buffer.empty())
+    {
+        shandler->SetWriteBytes(write_buffer);
+        shandler->SetWritePending();
+    }
+}
+
+uint8_t SERIAL_ReadUART()
+{
+    if(shandler == nullptr || !shandler->IsSerialInit())
+        return 0;
+    
+    if (!read_buffer.empty()) 
+    {
+        uint8_t byte = *read_buffer.cbegin();
+        read_buffer.erase(read_buffer.begin());
+        return byte;
+    }
+    return 0;
+}
+
+void SERIAL_PostUART(uint8_t byte)
+{
+    if(shandler == nullptr || !shandler->IsSerialInit())
+        return;
+    
+    if(write_buffer.size() < BUFFER_SIZE)
+        write_buffer.push_back(byte);
+}
+
+void SERIAL_Close()
+{
+    if(!shandler->IsSerialInit())
+        return;
+
+    linux_thread_run = false;
+    SDL_WaitThread(linux_io_thread, nullptr);
+    SDL_DestroyMutex(linux_io_lock);
+    
+    shandler->SerialClose();
+    delete shandler;
+    shandler = nullptr;
+}

--- a/src/serial_win32.cpp
+++ b/src/serial_win32.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2021, 2024 nukeykt
+ *
+ *  Redistribution and use of this code or any derivative works are permitted
+ *  provided that the following conditions are met:
+ *
+ *   - Redistributions may not be sold, nor may they be used in a commercial
+ *     product or activity.
+ *
+ *   - Redistributions that are modified from the original source must include the
+ *     complete source code, including the source code for all components used by a
+ *     binary built from the modified sources. However, as a special exception, the
+ *     source code distributed need not include anything that is normally distributed
+ *     (in either source or binary form) with the major components (compiler, kernel,
+ *     and so on) of the operating system on which the executable runs, unless that
+ *     component itself accompanies the executable.
+ *
+ *   - Redistributions must reproduce the above copyright notice, this list of
+ *     conditions and the following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <windows.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "serial.h"
+
+#define BUFFER_SIZE 4096 
+
+static int SERIAL_strnicmp(const char* a, const char* b, int len)
+{
+    int diff = 0;
+    char chrA, chrB;
+    for (int i = 0; i < len && !diff; i++)
+    {
+        chrA = *(a + i);
+        chrA |= 0x20 * (chrA >= 'A' && chrA <= 'Z');
+        chrB = *(b + i);
+        chrB |= 0x20 * (chrB >= 'A' && chrB <= 'Z');
+        diff |= chrA ^ chrB;
+    }
+    return diff;
+}
+
+static inline bool IsSerialPort(const char * path) {
+    size_t len = strlen(path);
+    if (*path == '\\' && len >= 4) {
+        if (memcmp(path, "\\\\.\\", 4) != 0)
+            return false;
+        len -= 4;
+        path += 4;
+    }
+    return len > 3 && SERIAL_strnicmp(path, "COM", 3) == 0 && atoi(path + 3) != 0;
+}
+
+static inline bool IsNamedPipe(const char * path) {
+    size_t pathlen = strnlen(path, 257);
+    if (pathlen < 10 || pathlen > 256)
+        return false;
+    if (memcmp(path, "\\\\", 2) != 0)
+        return false;
+    const char * hostname = path + 2;
+    const char * pipename = hostname;
+    while (*pipename != 0 && *pipename != '\\') pipename++;
+    if (hostname == pipename)
+        return false; // No hostname
+    if (strnlen(pipename, 7) < 7 || SERIAL_strnicmp(pipename, "\\pipe\\", 6) != 0)
+        return false;
+    pipename += 7;
+    return true;
+}
+
+static bool serial_init = false;
+static bool is_serial_port = false;
+static bool is_named_pipe = false;
+
+static char * serial_path;
+static HANDLE handle;
+static OVERLAPPED olRead;
+static OVERLAPPED olWrite;
+static uint8_t read_buffer[BUFFER_SIZE];
+static uint8_t * read_ptr = read_buffer;
+static uint8_t * read_end = read_buffer;
+static const uint8_t * read_limit = read_buffer + BUFFER_SIZE;
+static uint8_t write_buffer[BUFFER_SIZE];
+static uint8_t * write_ptr = write_buffer;
+static uint8_t * write_end = write_buffer;
+static const uint8_t * write_limit = write_buffer + BUFFER_SIZE;
+static bool read_pending = false;
+static bool write_pending = false;
+
+static void Cleanup() {
+    CloseHandle(handle);
+    CloseHandle(olRead.hEvent);
+    CloseHandle(olWrite.hEvent);
+    handle = INVALID_HANDLE_VALUE;
+    olRead.hEvent = INVALID_HANDLE_VALUE;
+    olWrite.hEvent = INVALID_HANDLE_VALUE;
+}
+
+static void ReportIOError(DWORD error) {
+    fprintf(stderr, "Serial I/O Error: %ld\n", error);
+    fflush(stderr);
+}
+
+bool SERIAL_Init(FE_Application& fe, std::string_view serial_port) {
+    if (serial_init) return 0;
+
+    char *path = new char[serial_port.length()];
+    strcpy(path, std::string(serial_port).c_str());
+
+    if (!IsSerialPort(path) && !IsNamedPipe(path)) {
+        fprintf(stderr, "Can't open '%s': Not a serial port or named pipe\n", path);
+        fflush(stderr);
+        return false;
+    }
+    is_serial_port = IsSerialPort(path);
+    is_named_pipe = !is_serial_port;
+
+    serial_path = new char[strlen(path) + 5];
+    if (is_serial_port && *path != '\\') {
+        memcpy(serial_path, "\\\\.\\", 4);
+    }
+    strcat(serial_path, path);
+
+    handle = CreateFileA(
+        serial_path,
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        FILE_FLAG_OVERLAPPED,
+        NULL
+    );
+    if (handle == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "Unable to open serial port: %s errcode: %ld\n", path, GetLastError());
+        fflush(stderr);
+        delete[] serial_path;
+        return false;
+    }
+
+    memset(&olRead, 0, sizeof(OVERLAPPED));
+    memset(&olWrite, 0, sizeof(OVERLAPPED));
+
+    olRead.hEvent = CreateEventA(NULL, true, false, NULL);
+    olWrite.hEvent = CreateEventA(NULL, true, false, NULL);
+
+    serial_init = 1;
+    printf("Opened serial port '%s'\n", path);
+    return true;
+}
+void SERIAL_Update(submcu_t& sm) {
+    (void)sm;
+
+    if (!serial_init || handle == INVALID_HANDLE_VALUE) return;
+    // printf("readptr: %04x readend: %04x\n", read_ptr - read_buffer, read_end - read_buffer);
+    if (read_ptr == read_end && !read_pending) {
+        if (read_end == read_limit) {
+            read_ptr = read_buffer;
+            read_end = read_buffer;
+        }
+        DWORD dwReads;
+        bool success = ReadFile(handle, read_end, read_limit - read_end, &dwReads, &olRead);
+        if (success) {
+            read_end += dwReads;
+            read_pending = false;
+        } else {
+            DWORD error = GetLastError();
+            if (error != ERROR_IO_PENDING) {
+                ReportIOError(error);
+                Cleanup();
+            } else {
+                read_pending = true;
+            }
+        }
+    }
+    if (read_pending) {
+        DWORD dwReads;
+        bool success = GetOverlappedResult(handle, &olRead, &dwReads, false);
+        if (success) {
+            read_end += dwReads;
+            read_pending = false;
+        } else {
+            DWORD error = GetLastError();
+            if (error != ERROR_IO_INCOMPLETE) {
+                ReportIOError(error);
+                Cleanup();
+            }
+        }
+    }
+    if (write_ptr != write_end && !write_pending) {
+        DWORD dwWrite;
+        int32_t len = write_end - write_ptr;
+        uint8_t *towrite = write_ptr;
+        if (len < 0) {
+            if (towrite == write_limit) {
+                len += BUFFER_SIZE;
+                towrite = write_buffer;
+                write_ptr = write_buffer;
+            } else {
+                len = write_limit - towrite;
+            }
+        }
+        bool success = WriteFile(handle, towrite, len, &dwWrite, &olWrite);
+        if (success) {
+            write_ptr += dwWrite;
+            write_pending = false;
+        } else {
+            DWORD error = GetLastError();
+            if (error != ERROR_IO_PENDING) {
+                ReportIOError(error);
+                Cleanup();
+            } else {
+                write_pending = true;
+            }
+        }
+    }
+    if (write_pending) {
+        DWORD dwWrite;
+        bool success = GetOverlappedResult(handle, &olWrite, &dwWrite, false);
+        if (success) {
+            write_ptr += dwWrite;
+            write_pending = false;
+        } else {
+            DWORD error = GetLastError();
+            if (error != ERROR_IO_INCOMPLETE) {
+                ReportIOError(error);
+                Cleanup();
+            }
+        }
+    }
+    if (write_ptr == write_limit) {
+        write_ptr = write_buffer;
+    }
+}
+bool SERIAL_HasData() {
+    return read_ptr < read_end;
+}
+uint8_t SERIAL_ReadUART() {
+    if (read_ptr < read_end) {
+        return *read_ptr++;
+    }
+    return 0;
+}
+void SERIAL_PostUART(uint8_t data) {
+    if (!serial_init || handle == INVALID_HANDLE_VALUE) return;
+    if (write_end == write_ptr - 1) {
+        fprintf(stderr, "SERIAL TX OVERFLOW, THIS IS A BUG\n");
+        fflush(stderr);
+        return;
+    }
+    *write_end++ = data;
+    if (write_end == write_limit) {
+        write_end = write_buffer;
+    }
+}
+void SERIAL_Close() {
+    if (!serial_init) return;
+    Cleanup();
+    free((void *) serial_path);
+}

--- a/src/submcu.cpp
+++ b/src/submcu.cpp
@@ -33,6 +33,7 @@
  */
 #include "submcu.h"
 #include "mcu.h"
+#include "serial.h"
 
 enum {
     SM_VECTOR_UART3_TX = 0,
@@ -51,11 +52,13 @@ enum {
     SM_DEV_P1_DATA = 0x00,
     SM_DEV_P1_DIR = 0x01,
     SM_DEV_RAM_DIR = 0x02,
+    SM_DEV_UART1_DATA = 0x04,
     SM_DEV_UART1_MODE_STATUS = 0x05,
     SM_DEV_UART1_CTRL = 0x06,
     SM_DEV_UART2_DATA = 0x08,
     SM_DEV_UART2_MODE_STATUS = 0x09,
     SM_DEV_UART2_CTRL = 0x0a,
+    SM_DEV_UART3_DATA = 0x0c,
     SM_DEV_UART3_MODE_STATUS = 0x0d,
     SM_DEV_UART3_CTRL = 0x0e,
     SM_DEV_IPCM0 = 0x10,
@@ -100,7 +103,12 @@ uint8_t SM_Read(submcu_t& sm, uint16_t address)
         address &= 0x1f;
         switch (address)
         {
-            case SM_DEV_UART2_DATA:
+            case SM_DEV_UART1_DATA: //Serial In
+            {
+                sm.uart_serial_rx_gotbyte = 0;
+                return sm.mcu->uart_serial_rx_byte;
+            }
+            case SM_DEV_UART2_DATA: //MIDI In
             {
                 sm.uart_rx_gotbyte = 0;
                 return sm.mcu->uart_rx_byte;
@@ -160,10 +168,13 @@ void SM_Write(submcu_t& sm, uint16_t address, uint8_t data)
         address &= 0x1f;
         switch (address)
         {
+            case SM_DEV_UART1_DATA: // Serial Out
+                SERIAL_PostUART(data);
+                break;
             case SM_DEV_UART2_DATA: // MIDI Out
                 if(sm.mcu->uart_tx_ptr - sm.mcu->uart_tx_buffer >= uart_buffer_size)
                 {
-                    printf("MIDI TX OVERFLOW, THIS IS A BUG\n");
+                    printf("MIDI TX OVERFLOW\n");
                     break;
                 }
                 if(data == 0xFE)
@@ -171,6 +182,8 @@ void SM_Write(submcu_t& sm, uint16_t address, uint8_t data)
                 if(sm.mcu->uart_tx_ptr == sm.mcu->uart_tx_buffer && (data & 0x00) == 0)
                     sm.mcu->uart_tx_ptr = sm.mcu->uart_tx_buffer +1;
                 *(sm.mcu->uart_tx_ptr)++ = data;
+                break;
+            case SM_DEV_UART3_DATA:
                 break;
             case SM_DEV_P1_DATA:
                 MCU_WriteP1(*sm.mcu, data);
@@ -1448,6 +1461,27 @@ void SM_UpdateUART(submcu_t& sm)
     mcu.uart_rx_delay = sm.cycles + 3000 * 4;
 }
 
+void SM_UpdateSerial(submcu_t& sm)
+{
+    if((sm.device_mode[SM_DEV_UART1_CTRL]&4) == 0)
+        return;
+    
+    if(!SERIAL_HasData()) //No byte
+        return;
+    
+    if(sm.uart_serial_rx_gotbyte)
+        return;
+
+    if(sm.cycles < sm.mcu->uart_serial_rx_delay)
+        return;
+
+    sm.mcu->uart_serial_rx_byte = SERIAL_ReadUART();
+    sm.uart_serial_rx_gotbyte = 1;
+    sm.device_mode[SM_DEV_INT_REQUEST] |= 0x80;
+
+    sm.mcu->uart_serial_rx_delay = sm.cycles + 3000 * 4;
+}
+
 void SM_Update(submcu_t& sm, uint64_t cycles)
 {
     while (sm.cycles < cycles * 5)
@@ -1464,6 +1498,8 @@ void SM_Update(submcu_t& sm, uint64_t cycles)
         sm.cycles += 12 * 4; // FIXME
         
         SM_UpdateTimer(sm);
+        SM_UpdateSerial(sm);
         SM_UpdateUART(sm);
+        SERIAL_Update(sm);
     }
 }


### PR DESCRIPTION
# Add Serial Support
**What is working:**
- [x] Serial Implementation
- [x] Serial IO on POSIX environment
- [x] Serial IO on WIN32 environment
- [x] nuked-sc55-render

## Regarding nuked-sc55-render
Currently the Serial IO calls happen on submcu.cpp which is not the correct place to call them.
Looking to call them in a different location similar to how MIDI IN and OUT are handled.
Currently it's working using dummy serial handling.