### PR TITLE
Update MIDI Out implementation

### DIFF
--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -490,6 +490,14 @@ bool FE_OpenAudio(FE_Application& fe, const FE_Parameters& params)
     return false;
 }
 
+void FE_SetMIDIOutCallback(FE_Application& fe)
+{
+    for(size_t i = 0; i < fe.instances_in_use; i++)
+    {
+        fe.instances[i].emu.SetMidiCallback(MIDI_SetMIDIOutCallBack);
+    }
+}
+
 template <typename SampleT>
 void FE_RunInstanceSDL(FE_Instance& instance)
 {
@@ -1175,8 +1183,12 @@ int main(int argc, char *argv[])
 
     if (!MIDI_Init(frontend, params.midiin_device, params.midiout_device))
     {
-        fprintf(stderr, "ERROR: Failed to initialize the MIDI Input.\nWARNING: Continuing without MIDI Input...\n");
+        fprintf(stderr, "ERROR: Failed to initialize the MIDI Devices.\nWARNING: Continuing without MIDI ...\n");
         fflush(stderr);
+    }
+    else if (!params.midiout_device.empty())
+    {
+        FE_SetMIDIOutCallback(frontend);
     }
 
     for (size_t i = 0; i < frontend.instances_in_use; ++i)

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -1181,9 +1181,15 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    if (!params.midiout_device.empty() && params.romset == Romset::ST)
+    {
+        fprintf(stderr, "MIDI Output is not available for SC-55st, continuing with only MIDI Input");
+        params.midiout_device = "";
+    }
+
     if (!MIDI_Init(frontend, params.midiin_device, params.midiout_device))
     {
-        fprintf(stderr, "ERROR: Failed to initialize the MIDI Devices.\nWARNING: Continuing without MIDI ...\n");
+        fprintf(stderr, "ERROR: Failed to initialize the MIDI Input.\nWARNING: Continuing without MIDI Input...\n");
         fflush(stderr);
     }
     else if (!params.midiout_device.empty())

--- a/src/standard/midi.h
+++ b/src/standard/midi.h
@@ -43,3 +43,4 @@ void MIDI_Quit(void);
 void MIDI_PrintDevices();
 void MIDI_PostShortMessage(uint8_t *message, int len);
 void MIDI_PostSysExMessage(uint8_t *message, int len);
+void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len);

--- a/src/standard/midi_rtmidi.cpp
+++ b/src/standard/midi_rtmidi.cpp
@@ -281,3 +281,10 @@ void MIDI_PostSysExMessage(uint8_t *message, int len) {
         s_midi_out->sendMessage(message, len);
     }
 }
+
+void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len)
+{
+    (void)userdata;
+    MIDI_PostShortMessage(message, len);
+
+}

--- a/src/standard/midi_win32.cpp
+++ b/src/standard/midi_win32.cpp
@@ -393,3 +393,10 @@ void MIDI_PostSysExMessage(uint8_t *message, int len) {
         midiOutUnprepareHeader(midi_out_handle, &buffer, sizeof buffer);
     }
 }
+
+void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len)
+{
+    (void)userdata;
+    MIDI_PostShortMessage(message, len);
+
+}


### PR DESCRIPTION
- Updated `mcu::midi_callback` to point to `MIDI_SetMIDIOutCallBack` for MIDI Output.
- Added check to prevent output port from opening for Roland-SC55st