### PR TITLE
Add Battery backup and JV880 NVRAM Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.19)
-project (nuked-SC55 VERSION 0.5.3 LANGUAGES CXX)
+project (nuked-SC55 VERSION 0.5.4 LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -3,6 +3,25 @@
 This fork is dependent on the changes on the fork [jcmoyer/Nuked-SC55](https://github.com/jcmoyer/Nuked-SC55)
 For **FULL CHANGELOG** from please check [jcmoyer/Nuked-SC55/CHANGELOG.md](https://github.com/jcmoyer/Nuked-SC55/blob/master/CHANGELOG.md)
 
+# Version 0.5.4 (2025-04-14)
+
+Jist of changes are follows:
+- Add SRAM read and write support for SC-55mk1, SC-55mk2, JV880, SC-155, SC-155mk2
+- Add NVRAM read and write support for JV880
+- Updated `DEV_SSR`
+- Fix MIDI TX and SERIAL TX
+- SC-55mk2 now has default GS Reset
+- Added SDL Application name
+
+# Version 0.5.3 (2025-04-08)
+
+Jist of changes are follows:
+- Updated SC-55 background
+- Added Serial IO Support for SC-55mk2 and SC-55st
+- Prints controls when using in JV880 and SC-55mk1/mk2 mode.
+- Fixed bugs in MIDI Out
+- Improved volume handling in GUI
+
 # Version 0.5.2 (2025-04-03)
 
 Jist of changes are follows:

--- a/documentation/USAGE.md
+++ b/documentation/USAGE.md
@@ -181,6 +181,7 @@ Emulator options:
   -r, --reset     gs|gm                         Reset system in GS or GM mode.
   -n, --instances <count>                       Set number of emulator instances.
   --no-lcd                                      Run without LCDs.
+  --nvram <filename>                            Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>                     Sets the directory to load roms from.
@@ -217,12 +218,23 @@ Emulator options:
   -r, --reset     gs|gm        Send GS or GM reset before rendering.
   -n, --instances <count>      Number of emulators to use (increases effective polyphony, but
                                takes longer to render)
+  --nvram <filename>           Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>    Sets the directory to load roms from. Romset will be autodetected when
                                not also passing --romset.
   --romset <name>              Sets the romset to load. Same as frontend's romsets without '--'
 ```
+
+### Regarding SRAM and NVRAM
+
+With version 0.5.4, the emulator supports SRAM saving for SC-55mk1, SC-55mk2, JV880, SC-155, SC-155mk2
+and NVRAM read and write support for JV880.
+
+JV880 needs NVRAM file passed via `--nvram`.
+
+Also the file where SRAM and NVRAM will be saved will have a suffix incidicating the corresponding
+emulator instance. Do not that the implementation of JV880 NVRAM has a [bug](https://github.com/jcmoyer/Nuked-SC55/issues/36#issuecomment-2781603485)
 
 ### Regarding Buffer Size
 

--- a/src/backend/emu.h
+++ b/src/backend/emu.h
@@ -88,6 +88,8 @@ public:
 
     void Step();
 
+    bool WriteSRAM(const std::filesystem::path& base_path);
+
     mcu_t& GetMCU() { return *m_mcu; }
     pcm_t& GetPCM() { return *m_pcm; }
     lcd_t& GetLCD() { return *m_lcd; }

--- a/src/backend/mcu.cpp
+++ b/src/backend/mcu.cpp
@@ -186,6 +186,7 @@ void MCU_DeviceWrite(mcu_t& mcu, uint32_t address, uint8_t data)
     case DEV_P7DDR:
         break;
     case DEV_SCR:
+        MCU_Interrupt_SetRequest(mcu, INTERRUPT_SOURCE_UART_TX, (data & 0x80) != 0 && (mcu.dev_register[DEV_SSR] & 0x80) != 0);
         break;
     case DEV_WCR:
         break;
@@ -282,7 +283,7 @@ void MCU_DeviceWrite(mcu_t& mcu, uint32_t address, uint8_t data)
         {
             mcu.dev_register[address] &= ~0x10;
         }
-        break;
+        return;
     }
     default:
         address += 0;
@@ -378,7 +379,7 @@ void MCU_DeviceReset(mcu_t& mcu)
     // mcu.dev_register[0x00] = 0x03;
     // mcu.dev_register[0x7c] = 0x87;
     mcu.dev_register[DEV_RAME] = 0x80;
-    mcu.dev_register[DEV_SSR] = 0x80;
+    mcu.dev_register[DEV_SSR] = 0x87;
 }
 
 void MCU_UpdateAnalog(mcu_t& mcu, uint64_t cycles)

--- a/src/backend/submcu.cpp
+++ b/src/backend/submcu.cpp
@@ -116,13 +116,15 @@ uint8_t SM_Read(submcu_t& sm, uint16_t address)
             case SM_DEV_UART1_MODE_STATUS:
             {
                 uint8_t ret = 0;
-                ret        |= 5;
+                ret        |= 1;
+                ret        |= 4; // Serial output enabled
                 return ret;
             }
             case SM_DEV_UART2_MODE_STATUS:
             {
                 uint8_t ret = sm.uart_rx_gotbyte << 1;
-                ret        |= 5;
+                ret        |= 1;
+                ret        |= 4; // Midi output enabled
                 return ret;
             }
             case SM_DEV_UART3_MODE_STATUS:
@@ -1436,7 +1438,7 @@ void SM_UpdateTimer(submcu_t& sm)
             else
                 sm.timer_prescaler--;
         }
-        sm.timer_cycles += 16;
+        sm.timer_cycles += 120;
     }
 }
 
@@ -1444,7 +1446,7 @@ void SM_UpdateUART(submcu_t& sm)
 {
     mcu_t& mcu = *sm.mcu;
 
-    if ((sm.device_mode[SM_DEV_UART1_CTRL] & 4) == 0) // RX disabled
+    if ((sm.device_mode[SM_DEV_UART2_CTRL] & 4) == 0) // RX disabled
         return;
     if (mcu.uart_write_ptr == mcu.uart_read_ptr) // no byte
         return;

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -143,6 +143,7 @@ struct FE_Parameters
     bool no_lcd               = false;
     bool disable_oversampling = false;
     std::optional<uint32_t> asio_sample_rate;
+    std::filesystem::path nvram_filename;
 };
 
 bool FE_AllocateInstance(FE_Application& container, FE_Instance** result)
@@ -679,10 +680,8 @@ bool FE_Init()
     return true;
 }
 
-bool FE_CreateInstance(FE_Application& container, const std::filesystem::path& base_path, const FE_Parameters& params)
+bool FE_CreateInstance(FE_Application& container, const FE_Parameters& params, size_t instance_number)
 {
-    (void)base_path;
-
     FE_Instance* fe = nullptr;
 
     if (!FE_AllocateInstance(container, &fe))
@@ -691,22 +690,26 @@ bool FE_CreateInstance(FE_Application& container, const std::filesystem::path& b
         return false;
     }
 
-    fe->format       = params.output_format;
-    fe->buffer_size  = params.buffer_size;
-    fe->buffer_count = params.buffer_count;
+    fe->format        = params.output_format;
+    fe->buffer_size   = params.buffer_size;
+    fe->buffer_count  = params.buffer_count;
 
     if (!params.no_lcd)
     {
         fe->sdl_lcd = std::make_unique<LCD_SDL_Backend>();
     }
 
-    if (!fe->emu.Init({.lcd_backend = fe->sdl_lcd.get(), .serial_type = params.serial_type}))
+    if (!fe->emu.Init({.instance_id        = instance_number,
+                       .rom_directory      = *params.rom_directory, 
+                       .lcd_backend        = fe->sdl_lcd.get(), 
+                       .serial_type        = params.serial_type, 
+                       .nvram_basefilename = params.nvram_filename}))
     {
         fprintf(stderr, "ERROR: Failed to init emulator.\n");
         return false;
     }
 
-    if (!fe->emu.LoadRoms(params.romset, params.revision, *params.rom_directory))
+    if (!fe->emu.LoadRoms(params.romset, params.revision))
     {
         fprintf(stderr, "ERROR: Failed to load roms.\n");
         return false;
@@ -731,13 +734,9 @@ void FE_DestroyInstance(FE_Instance& instance)
         SDL_FreeAudioStream(instance.stream);
         instance.stream = nullptr;
     }
+#else
+    (void)instance;
 #endif
-    std::filesystem::path base_path = P_GetProcessPath().parent_path();
-
-    if (std::filesystem::exists(base_path / "../share/nuked-sc55"))
-        base_path = base_path / "../share/nuked-sc55";
-
-    instance.emu.WriteSRAM(base_path);
 }
 
 void FE_Quit(FE_Application& container)
@@ -1014,6 +1013,15 @@ FE_ParseError FE_ParseCommandLine(int argc, char* argv[], FE_Parameters& result)
                 return FE_ParseError::RomDirectoryNotFound;
             }
         }
+        else if (reader.Any("--nvram"))
+        {
+            if (!reader.Next())
+            {
+                return FE_ParseError::UnexpectedEnd;
+            }
+
+            result.nvram_filename = reader.Arg();
+        }
         else if (reader.Any("--mk2"))
         {
             result.romset = Romset::MK2;
@@ -1148,6 +1156,7 @@ Emulator options:
   -r, --reset     none|gs|gm                    Reset system in GS or GM mode. (No GM in MK1 1.00 & 1.10)
   -n, --instances <count>                       Set number of emulator instances.
   --no-lcd                                      Run without LCDs.
+  --nvram <filename>                            Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>                     Sets the directory to load roms from.
@@ -1293,18 +1302,6 @@ int main(int argc, char *argv[])
         fprintf(stderr, "ROM set autodetect: %s\n", EMU_RomsetName(params.romset));
     }
 
-    EMU_SystemReset reset = EMU_SystemReset::NONE;
-    if (params.reset)
-    {
-        reset = *params.reset;
-    }
-    else if (!params.reset && params.romset == Romset::MK2)
-    {
-        // user didn't explicitly pass a reset and we're using a buggy romset
-        fprintf(stderr, "WARNING: No reset specified with mk2 romset; using gs\n");
-        reset = EMU_SystemReset::GS_RESET;
-    }
-
     if (!FE_Init())
     {
         fprintf(stderr, "FATAL ERROR: Failed to initialize frontend\n");
@@ -1313,7 +1310,7 @@ int main(int argc, char *argv[])
 
     for (size_t i = 0; i < params.instances; ++i)
     {
-        if (!FE_CreateInstance(frontend, base_path, params))
+        if (!FE_CreateInstance(frontend, params, i))
         {
             fprintf(stderr, "FATAL ERROR: Failed to create instance %zu\n", i);
             return 1;
@@ -1363,9 +1360,23 @@ int main(int argc, char *argv[])
         }
     }
 
-    for (size_t i = 0; i < frontend.instances_in_use; ++i)
+    if (params.reset)
     {
-        frontend.instances[i].emu.PostSystemReset(reset);
+        for (size_t i = 0; i < frontend.instances_in_use; ++i)
+        {
+            frontend.instances[i].emu.PostSystemReset(*params.reset);
+        }
+    }
+    else
+    {
+        for (size_t i = 0; i < frontend.instances_in_use; ++i)
+        {
+            if (!frontend.instances[i].emu.IsSRAMLoaded())
+            {
+                fprintf(stderr, "WARNING: No reset specified with mk2 romset; using gs\n");
+                frontend.instances[i].emu.PostSystemReset(EMU_SystemReset::GS_RESET);
+            }
+        }
     }
 
     FE_PrintControls(params.romset);

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -731,9 +731,13 @@ void FE_DestroyInstance(FE_Instance& instance)
         SDL_FreeAudioStream(instance.stream);
         instance.stream = nullptr;
     }
-#else
-    (void)instance;
 #endif
+    std::filesystem::path base_path = P_GetProcessPath().parent_path();
+
+    if (std::filesystem::exists(base_path / "../share/nuked-sc55"))
+        base_path = base_path / "../share/nuked-sc55";
+
+    instance.emu.WriteSRAM(base_path);
 }
 
 void FE_Quit(FE_Application& container)

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -46,6 +46,7 @@
 #include "ringbuffer.h"
 #include "serial.h"
 #include <SDL.h>
+#include <SDL_hints.h>
 #include <optional>
 #include <thread>
 
@@ -664,8 +665,12 @@ BOOL WINAPI FE_CtrlCHandler(DWORD dwCtrlType)
 }
 #endif
 
-bool FE_Init()
+bool FE_Init(Romset romset)
 {
+    std::string name = "Nuked SC-55: ";
+    name += EMU_RomsetName(romset);
+    SDL_SetHint(SDL_HINT_APP_NAME, name.c_str());
+
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0)
     {
         fprintf(stderr, "FATAL ERROR: Failed to initialize the SDL2: %s.\n", SDL_GetError());
@@ -1302,7 +1307,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "ROM set autodetect: %s\n", EMU_RomsetName(params.romset));
     }
 
-    if (!FE_Init())
+    if (!FE_Init(params.romset))
     {
         fprintf(stderr, "FATAL ERROR: Failed to initialize frontend\n");
         return 1;


### PR DESCRIPTION
- [x] Copy SRAM save and Load support from kebufu/nuked-sc55@36a9f1c & kebufu/nuked-sc55@36a9f1c
- [x] Copy JV880 NVRAM Load and Save support from jcmoyer/nuked-sc55@3297930
- [x] Fix SRAM Writing for non base path ROM directory.
- [x] Added multi-instance individual SRAM and NVRAM support

- Updated `DEV_SSR` behavour
- Fixed submcu MIDI TX and Serial TX
- Added SDL Application name
- Bumped to version 5.4

Closes: https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/issues/14