### PR TITLE
Change MIDI OUT Callback function

### DIFF
--- a/src/backend/emu.cpp
+++ b/src/backend/emu.cpp
@@ -104,9 +104,9 @@ void Emulator::SetSampleCallback(mcu_sample_callback callback, void* userdata)
     m_mcu->sample_callback   = callback;
 }
 
-void Emulator::SetMidiCallback(mcu_midi_callback callback)
+void Emulator::SetMidiOutCallback(mcu_midiout_callback callback)
 {
-    m_mcu->midi_callback = callback;
+    m_mcu->midiout_callback = callback;
 }
 
 void Emulator::SetSerialHasDataCallback(sm_serial_hasdata_callback callback)

--- a/src/backend/emu.h
+++ b/src/backend/emu.h
@@ -86,7 +86,7 @@ public:
     void StopLCD();
 
     void SetSampleCallback(mcu_sample_callback callback, void* userdata);
-    void SetMidiCallback(mcu_midi_callback callback);
+    void SetMidiOutCallback(mcu_midiout_callback callback);
 
     void SetSerialHasDataCallback(sm_serial_hasdata_callback callback);
     void SetSerialReadCallback(sm_serial_read_callback callback);

--- a/src/backend/mcu.cpp
+++ b/src/backend/mcu.cpp
@@ -796,7 +796,7 @@ void MCU_DefaultSampleCallback(void* userdata, const AudioFrame<int32_t>& frame)
     (void)frame;
 }
 
-void MCU_DefaultMidiCallback(void* userdata, uint8_t* message, int len)
+void MCU_DefaultMidiOutCallback(void* userdata, uint8_t* message, int len)
 {
     (void)userdata;
     (void)message;
@@ -926,7 +926,7 @@ void MCU_UpdateUART(mcu_t& mcu)
         if (*(mcu.uart_tx_ptr - 1) == 0xF7) 
         {
             len = mcu.uart_tx_ptr - tx_buffer;
-            mcu.midi_callback(mcu.callback_userdata, tx_buffer, len);
+            mcu.midiout_callback(mcu.callback_userdata, tx_buffer, len);
             mcu.uart_tx_ptr = mcu.uart_tx_buffer;
         }
     } 
@@ -951,7 +951,7 @@ void MCU_UpdateUART(mcu_t& mcu)
         }
         if (mcu.uart_tx_ptr - tx_buffer >= len) 
         {
-            mcu.midi_callback(mcu.callback_userdata, tx_buffer, len);
+            mcu.midiout_callback(mcu.callback_userdata, tx_buffer, len);
             mcu.uart_tx_ptr = mcu.uart_tx_buffer;
         }
     }

--- a/src/backend/mcu.h
+++ b/src/backend/mcu.h
@@ -219,10 +219,10 @@ enum class Computerswitch {
 constexpr size_t ROMSET_COUNT = 9;
 
 typedef void(*mcu_sample_callback)(void* userdata, const AudioFrame<int32_t>& frame);
-typedef void (*mcu_midi_callback)(void* userdata, uint8_t* message, int len);
+typedef void (*mcu_midiout_callback)(void* userdata, uint8_t* message, int len);
 
 void MCU_DefaultSampleCallback(void* userdata, const AudioFrame<int32_t>& frame);
-void MCU_DefaultMidiCallback(void* userdata, uint8_t* message, int len);
+void MCU_DefaultMidiOutCallback(void* userdata, uint8_t* message, int len);
 
 struct mcu_t {
     uint16_t r[8]{};
@@ -308,9 +308,9 @@ struct mcu_t {
 
     uint16_t volume = 8250;
 
-    void* callback_userdata             = nullptr;
-    mcu_sample_callback sample_callback = MCU_DefaultSampleCallback;
-    mcu_midi_callback midi_callback     = MCU_DefaultMidiCallback;
+    void* callback_userdata                 = nullptr;
+    mcu_sample_callback sample_callback     = MCU_DefaultSampleCallback;
+    mcu_midiout_callback midiout_callback   = MCU_DefaultMidiOutCallback;
 };
 
 void MCU_Init(mcu_t& mcu, submcu_t& sm, pcm_t& pcm, mcu_timer_t& timer, lcd_t& lcd, Computerswitch sw);

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -499,7 +499,7 @@ void FE_SetMIDIOutCallback(FE_Application& fe)
 {
     for(size_t i = 0; i < fe.instances_in_use; i++)
     {
-        fe.instances[i].emu.SetMidiCallback(MIDI_SetMIDIOutCallBack);
+        fe.instances[i].emu.SetMidiOutCallback(MIDI_MIDIOutCallBack);
     }
 }
 

--- a/src/standard/midi.h
+++ b/src/standard/midi.h
@@ -43,4 +43,4 @@ void MIDI_Quit(void);
 void MIDI_PrintDevices();
 void MIDI_PostShortMessage(uint8_t *message, int len);
 void MIDI_PostSysExMessage(uint8_t *message, int len);
-void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len);
+void MIDI_MIDIOutCallBack(void* userdata, uint8_t* message, int len);

--- a/src/standard/midi_rtmidi.cpp
+++ b/src/standard/midi_rtmidi.cpp
@@ -282,9 +282,9 @@ void MIDI_PostSysExMessage(uint8_t *message, int len) {
     }
 }
 
-void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len)
+void MIDI_MIDIOutCallBack(void* userdata, uint8_t* message, int len)
 {
     (void)userdata;
-    MIDI_PostShortMessage(message, len);
+    MIDI_PostSysExMessage(message, len);
 
 }

--- a/src/standard/midi_win32.cpp
+++ b/src/standard/midi_win32.cpp
@@ -394,9 +394,9 @@ void MIDI_PostSysExMessage(uint8_t *message, int len) {
     }
 }
 
-void MIDI_SetMIDIOutCallBack(void* userdata, uint8_t* message, int len)
+void MIDI_MIDIOutCallBack(void* userdata, uint8_t* message, int len)
 {
     (void)userdata;
-    MIDI_PostShortMessage(message, len);
+    MIDI_PostSysExMessage(message, len);
 
 }


### PR DESCRIPTION
Change MIDI OUT callback from `MIDI_PostShortMessage` to `MIDI_PostSysExMessage`
 
Closes: https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/issues/10