### PR TITLE
Fix LCD Background loading when deployed in /usr/bin

### DIFF
--- a/src/standard/lcd_sdl.cpp
+++ b/src/standard/lcd_sdl.cpp
@@ -193,9 +193,13 @@ bool LCD_SDL_Backend::Start(lcd_t& lcd)
 
     title += RomsetName(m_lcd->mcu->romset);
 
+    std::filesystem::path base_path = common::GetProcessPath().parent_path();
+
+    if (std::filesystem::exists(base_path / "../share/nuked-sc55"))
+        base_path = base_path / "../share/nuked-sc55";
+
     if (m_lcd->mcu->romset == Romset::MK1 || m_lcd->mcu->romset == Romset::MK2)
     {
-        std::filesystem::path base_path = common::GetProcessPath().parent_path();
         m_image = SDL_LoadBMP((const char*)(base_path / "sc55_background.bmp").u8string().c_str());
         if (m_image)
         {
@@ -206,7 +210,6 @@ bool LCD_SDL_Backend::Start(lcd_t& lcd)
     }
     else if (m_lcd->mcu->romset == Romset::JV880)
     {
-        std::filesystem::path base_path = common::GetProcessPath().parent_path();
         m_image = SDL_LoadBMP((const char*)(base_path / "jv880_background.bmp").u8string().c_str());
         if (m_image)
         {


### PR DESCRIPTION
Currently the emulator looks for the backgrounds in the binary directory. Which works fine as long as it's a self contained deployment.
However when deployed as a system binary/package the binary goes to `/usr/bin` and the backgrounds to `/usr/share/nuked-sc55`, preventing the binary from detecting the backgrounds.

To fix this, the path detection from `main.cpp` will be copied:
https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/blob/bafc1cc6620f1f5e53b9f2bff49f1aa2f2a49c21/src/standard/main.cpp#L1578-L1581
to `lcd_sdl.cpp` replacing line 198:
https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/blob/bafc1cc6620f1f5e53b9f2bff49f1aa2f2a49c21/src/standard/lcd_sdl.cpp#L196-L198
and line 209:
https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/blob/bafc1cc6620f1f5e53b9f2bff49f1aa2f2a49c21/src/standard/lcd_sdl.cpp#L207-L209

Closes: https://github.com/linoshkmalayil/Nuked-SC55-GUI-Float/issues/68