### PR TITLE
Automatic NVRAM loading for JV880

### DIFF
--- a/documentation/USAGE.md
+++ b/documentation/USAGE.md
@@ -202,7 +202,6 @@ Emulator options:
   -r, --reset     none|gs|gm                     Reset system in GS or GM mode. (No GM in MK1 1.00 & 1.10)
   -n, --instances <count>                        Set number of emulator instances.
   --no-lcd                                       Run without LCDs.
-  --nvram <filename>                             Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>                      Sets the directory to load roms from.
@@ -240,7 +239,6 @@ Emulator options:
   -r, --reset     none|gs|gm   Send GS or GM reset before rendering.
   -n, --instances <count>      Number of emulators to use (increases effective polyphony, but
                                takes longer to render)
-  --nvram <filename>           Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>    Sets the directory to load roms from. Romset will be autodetected when
@@ -284,8 +282,6 @@ or on Linux and MacOS:
 
 With version 0.5.4, the emulator supports SRAM saving for SC-55mk1, SC-55mk2, JV880, SC-155, SC-155mk2
 and NVRAM read and write support for JV880.
-
-JV880 needs NVRAM file passed via `--nvram`.
 
 Also the file where SRAM and NVRAM will be saved will have a suffix incidicating the corresponding
 emulator instance. Do note that the implementation of JV880 NVRAM has a [bug](https://github.com/jcmoyer/Nuked-SC55/issues/36#issuecomment-2781603485)

--- a/src/backend/emu.cpp
+++ b/src/backend/emu.cpp
@@ -116,7 +116,7 @@ void Emulator::SetSerialPostCallback(sm_serial_post_callback callback)
     m_sm->serial_post_callback = callback;
 }
 
-constexpr int ROM_SET_N_FILES = 7;
+constexpr int ROM_SET_N_FILES = 8;
 
 const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
 {
@@ -127,7 +127,8 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "waverom2.bin",
         "rom_sm.bin",
         "",
-        "memory.bin"
+        "memory.bin",
+        "",
     },
 
     {
@@ -136,6 +137,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "waverom1.bin",
         "waverom2.bin",
         "rom_sm.bin",
+        "",
         "",
         "",
     },
@@ -148,6 +150,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "sc55_waverom3.bin",
         "",
         "sc55_memory.bin",
+        "",
     },
 
     {
@@ -156,6 +159,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "cm300_waverom1.bin",
         "cm300_waverom2.bin",
         "cm300_waverom3.bin",
+        "",
         "",
         "",
     },
@@ -167,7 +171,8 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "jv880_waverom2.bin",
         "jv880_waverom_expansion.bin",
         "jv880_waverom_pcmcard.bin",
-        "jv880_memory.bin"
+        "jv880_memory.bin",
+        "jv880_nvram.bin",
     },
 
     {
@@ -175,6 +180,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "scb55_rom2.bin",
         "scb55_waverom1.bin",
         "scb55_waverom2.bin",
+        "",
         "",
         "",
         "",
@@ -188,6 +194,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "",
         "",
         "",
+        "",
     },
 
     {
@@ -197,7 +204,8 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "sc155_waverom2.bin",
         "sc155_waverom3.bin",
         "",
-        "sc155_memory.bin"
+        "sc155_memory.bin",
+        "",
     },
 
     {
@@ -208,6 +216,7 @@ const char* roms[(size_t)ROMSET_COUNT][ROM_SET_N_FILES] =
         "rom_sm.bin",
         "",
         "memory.bin",
+        "",
     },
 };
 
@@ -536,10 +545,10 @@ void Emulator::WriteSRAM()
 
 void Emulator::ReadNVRAM()
 {
-    if (!m_options.nvram_filename.empty() && m_mcu->is_jv880)
+    if (m_mcu->is_jv880)
     {
         // append instance number so that multiple instances don't clobber each other's nvram
-        std::filesystem::path nvram_file = m_options.nvram_filename;
+        std::filesystem::path nvram_file = m_options.rom_directory / roms[(size_t)m_mcu->romset][7];
         nvram_file                      += std::to_string(m_options.instance_id);
 
         std::ifstream file(nvram_file, std::ios::binary);
@@ -562,10 +571,10 @@ void Emulator::WriteNVRAM()
         return;
     }
 
-    if (!m_options.nvram_filename.empty() && m_mcu->is_jv880)
+    if (m_mcu->is_jv880)
     {
         // append instance number so that multiple instances don't clobber each other's nvram
-        std::filesystem::path nvram_file = m_options.nvram_filename;
+        std::filesystem::path nvram_file = m_options.rom_directory / roms[(size_t)m_mcu->romset][7];
         nvram_file                      += std::to_string(m_options.instance_id);
 
         std::ofstream file(nvram_file, std::ios::binary);

--- a/src/backend/emu.h
+++ b/src/backend/emu.h
@@ -56,8 +56,6 @@ struct EMU_Options
     LCD_Backend* lcd_backend = nullptr;
     // Computer Switch for IO: Serial/MIDI, defaults to MIDI.
     Computerswitch serial_type = Computerswitch::MIDI;
-    // If not empty, nvram will be saved to and loaded from here. JV-880 only.
-    std::filesystem::path nvram_filename;
 };
 
 enum class EMU_SystemReset {

--- a/src/renderer/main.cpp
+++ b/src/renderer/main.cpp
@@ -57,7 +57,6 @@ struct R_Parameters
     std::string_view romset_name;
     bool debug = false;
     R_EndBehavior end_behavior = R_EndBehavior::Cut;
-    std::filesystem::path nvram_filename;
     bool legacy_romset_detection = false;
     bool dump_emidi_loop_points = false;
     float gain = 1.0f;
@@ -194,15 +193,6 @@ R_ParseError R_ParseCommandLine(int argc, char* argv[], R_Parameters& result)
             {
                 return R_ParseError::RomDirectoryNotFound;
             }
-        }
-        else if (reader.Any("--nvram"))
-        {
-            if (!reader.Next())
-            {
-                return R_ParseError::UnexpectedEnd;
-            }
-
-            result.nvram_filename = reader.Arg();
         }
         else if (reader.Any("--romset"))
         {
@@ -1318,17 +1308,9 @@ bool R_RenderTrack(const SMF_Data& data, const R_Parameters& params)
     R_TrackRenderState render_states[SMF_CHANNEL_COUNT];
     for (size_t i = 0; i < instances; ++i)
     {
-        std::filesystem::path this_nvram = params.nvram_filename;
-        if (!this_nvram.empty())
-        {
-            // append instance number so that multiple instances don't clobber each other's nvram
-            this_nvram += std::to_string(i);
-        }
-
         render_states[i].emu.Init({.instance_id        = i,
                                    .rom_directory      = params.rom_directory,
-                                   .lcd_backend        = nullptr,
-                                   .nvram_filename = this_nvram});
+                                   .lcd_backend        = nullptr});
 
         RomLocationSet loaded{};
         if (!render_states[i].emu.LoadRoms(load_result.romset, romset_info, &loaded))
@@ -1507,7 +1489,6 @@ Emulator options:
   -r, --reset     none|gs|gm   Send GS or GM reset before rendering.
   -n, --instances <count>      Number of emulators to use (increases effective polyphony, but
                                takes longer to render)
-  --nvram <filename>           Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>    Sets the directory to load roms from. Romset will be autodetected when

--- a/src/standard/main.cpp
+++ b/src/standard/main.cpp
@@ -162,7 +162,6 @@ struct FE_Parameters
     std::optional<uint32_t> asio_sample_rate;
     std::string asio_left_channel;
     std::string asio_right_channel;
-    std::filesystem::path nvram_filename;
     FE_AdvancedParameters adv;
     float gain = 1.0f;
 };
@@ -931,18 +930,10 @@ bool FE_CreateInstance(FE_Application& container, const std::filesystem::path& b
         fe->sdl_lcd = std::make_unique<LCD_SDL_Backend>();
     }
 
-    std::filesystem::path this_nvram = params.nvram_filename;
-    if (!this_nvram.empty())
-    {
-        // append instance number so that multiple instances don't clobber each other's nvram
-        this_nvram += std::to_string(container.instances_in_use - 1);
-    }
-
     if (!fe->emu.Init({.instance_id        = instance_number,
                        .rom_directory      = *params.rom_directory, 
                        .lcd_backend        = fe->sdl_lcd.get(), 
-                       .serial_type        = params.serial_type, 
-                       .nvram_filename     = this_nvram}))
+                       .serial_type        = params.serial_type}))
     {
         fprintf(stderr, "ERROR: Failed to init emulator.\n");
         return false;
@@ -1277,15 +1268,6 @@ FE_ParseError FE_ParseCommandLine(int argc, char* argv[], FE_Parameters& result)
                 return FE_ParseError::RomDirectoryNotFound;
             }
         }
-        else if (reader.Any("--nvram"))
-        {
-            if (!reader.Next())
-            {
-                return FE_ParseError::UnexpectedEnd;
-            }
-
-            result.nvram_filename = reader.Arg();
-        }
         else if (reader.Any("--romset"))
         {
             if (!reader.Next())
@@ -1445,7 +1427,6 @@ Emulator options:
   -r, --reset     none|gs|gm                    Reset system in GS or GM mode. (No GM in MK1 1.00 & 1.10)
   -n, --instances <count>                       Set number of emulator instances.
   --no-lcd                                      Run without LCDs.
-  --nvram <filename>                            Saves and loads NVRAM to/from disk. JV-880 only.
 
 ROM management options:
   -d, --rom-directory <dir>                     Sets the directory to load roms from.


### PR DESCRIPTION
This will remove the need to manually pass a nvram file using `--nvram` argument for the JV880 and make it part of the romset like the SRAM saving and reading.

However I am debating on merging this change due the [bug](https://github.com/jcmoyer/Nuked-SC55/issues/36#issuecomment-2781603485)

If by any chance there is an nvram corruption, that corruption will persist till the nvram files are deleted.