### PR TITLE
Fix waverom corruption causing silent notes in JV-880 mode

### DIFF
--- a/src/backend/rom_io.cpp
+++ b/src/backend/rom_io.cpp
@@ -556,7 +556,7 @@ bool DetectRomsetsByHash(const std::filesystem::path& base_path,
                     if (IsWaverom(known.location))
                     {
                         rom_data.resize(buffer.size());
-                        unscramble(rom_data.data(), buffer.data(), (int)buffer.size());
+                        unscramble(buffer.data(), rom_data.data(), (int)buffer.size());
                     }
                     else
                     {

--- a/src/common/rom_loader.cpp
+++ b/src/common/rom_loader.cpp
@@ -45,7 +45,12 @@ LoadRomsetError LoadRomset(AllRomsetInfo&               romset_info,
 
         // When the user specifies a romset, we can speed up the loading process a bit.
         RomLocationSet desired{};
-        desired[(size_t)result.romset] = true;
+        // Iterate all RomLocation values: the caller knows the romset, so tell
+        // the detector to pre-load every location that this romset may use.
+        // Checking each location across the whole space is cheap and avoids
+        // the type mix-up of indexing a RomLocationSet with a Romset value.
+        for (size_t loc = 0; loc < desired.size(); ++loc)
+            desired[loc] = true;
 
         if (legacy_loader)
         {


### PR DESCRIPTION
## Problem

In JV-880 mode, certain patches (e.g. A Piano 1, A Piano 2) produce no sound
above specific key ranges, while other patches (e.g. JV String) work fine
across the full keyboard.

## Root cause

Two bugs in the ROM loading path that only produce symptoms when combined:

### Bug 1: Swapped src/dst in `unscramble()` call (`rom_io.cpp:559`)

In `DetectRomsetsByHash`, the `unscramble()` call had its arguments reversed:

```cpp
// Before (wrong): rom_data is zeroed buffer, buffer has real file data
unscramble(rom_data.data(), buffer.data(), (int)buffer.size());

// After (fixed):
unscramble(buffer.data(), rom_data.data(), (int)buffer.size());
```

The function signature is `unscramble(const uint8_t *src, uint8_t *dst, int len)`.
With the swapped order, it read from the zeroed `rom_data` buffer and wrote
into `buffer`, leaving `rom_data` filled with zeros.

### Bug 2: `RomLocationSet` indexed with `Romset` value (`rom_loader.cpp:48`)

```cpp
RomLocationSet desired{};              // std::array<bool, ROMLOCATION_COUNT>
desired[(size_t)result.romset] = true; // indexed with Romset, not RomLocation
```

`RomLocationSet` is indexed by `RomLocation` (0-7), but the code indexed it
with a `Romset` enum value. For JV-880 (`Romset::JV880 = 4`), this mapped to
`RomLocation::WAVEROM2 = 4`, so only WAVEROM2 was pre-loaded during hash
detection - through the broken `unscramble` path (Bug 1).

Other waveroms (WAVEROM1, WAVEROM3) were not pre-loaded, so they took the
correct on-demand path in `LoadRomset` (line 749) where `unscramble` is called
with the right argument order.

### Why both bugs were needed to trigger the symptom

| Waverom | Pre-loaded? | Path taken | `unscramble` correct? | Result |
|---------|-------------|------------|----------------------|--------|
| WAVEROM1 | No | `LoadRomset` (on-demand) | Yes | Correct |
| WAVEROM2 | Yes | `DetectRomsetsByHash` (pre-load) | No | **Corrupted (zeros)** |
| WAVEROM3 | No | `LoadRomset` (on-demand) | Yes | Correct |

Without Bug 2, all waveroms would be pre-loaded through the broken path -
more severe corruption, but easier to notice. Without Bug 1, pre-loading
works fine - no symptoms at all. Only the combination produces the subtle
partial-silence that went unnoticed.

## Fix

1. **`rom_io.cpp`**: Swap `src`/`dst` in the `unscramble()` call so the real
   file data (`buffer`) is the source and the destination buffer (`rom_data`)
   receives the unscrambled output.

2. **`rom_loader.cpp`**: Iterate all `RomLocation` values instead of indexing
   `RomLocationSet` with a `Romset` value. All locations relevant to the
   selected romset are now pre-loaded correctly.

## Testing

Verified on macOS with JV-880 romset: A Piano 1 and A Piano 2 now play all
notes across the full keyboard range. Other romsets (SC-55mkII, etc.) remain
unaffected.
